### PR TITLE
Add total_results in Response

### DIFF
--- a/pytineye/api.py
+++ b/pytineye/api.py
@@ -25,8 +25,9 @@ class TinEyeResponse(object):
     - `matches`, a list of Match objects.
     """
 
-    def __init__(self, matches):
+    def __init__(self, matches, total_results=None):
         self.matches = matches
+        self.total_results = total_results or 0
 
     def __repr__(self):
         return '%s(matches="%s")' % \
@@ -53,7 +54,8 @@ class TinEyeResponse(object):
                 for m in results.get('matches'):
                     match = Match._from_dict(m)
                     matches.append(match)
-        return TinEyeResponse(matches)
+        total_results = results.get('total_results')
+        return TinEyeResponse(matches, total_results)
 
 class Match(object):
     """

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -150,3 +150,11 @@ class TestTinEyeAPIRequest(unittest.TestCase):
             r = self.api.image_count()
         except TinEyeAPIError, e:
             assert True
+
+    def test_total_results_in_response(self):
+        """Test if TinEyeAPI.TinEyeResponse have total_results object."""
+        response = {
+            'results': {'total_results': 123, 'matches': []}
+        }
+        r = TinEyeResponse._from_dict(response)
+        self.assertEqual(r.total_results, 123)


### PR DESCRIPTION
*Response variables* in [search](http://api.tineye.com/rest/index.html#id21) have the **total_results** which is missed in `api.TinEyeResponse`, I just added it and also its corresponding test.