### PR TITLE
Add requirements.txt and test/__init__.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pycrypto==2.6.1
+simplejson==3.8.0
+urllib3


### PR DESCRIPTION
I added a requirements.txt file to help install the dependencies via pip. 

I locked down the versions of `pycrypto` and `simplejson` to the latest versions and left off a version for `urllib3` since pip throws errors whenever one is specified.

Also added an `__init__.py` file in the test directory.