### PR TITLE
Fix boundary string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+2.0.1
+-----
+* Modifying boundary string so it starts and ends with `--` for multipart requests.
+
 2.0.0
 -----
 * Fixed a bug in the construction of the string to sign.

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2017 TinEye
+Copyright (c) 2021 TinEye
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/generated_docs/index.html
+++ b/generated_docs/index.html
@@ -81,12 +81,12 @@
 </div>
 <p>Getting information about your search bundle:</p>
 <div class="highlight-python"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">api</span><span class="o">.</span><span class="n">remaining_searches</span><span class="p">()</span>
-<span class="go">{&#39;bundles&#39;: [{&#39;expire_date&#39;: datetime.datetime(2019, 3, 9, 14, 9, 12),</span>
+<span class="go">{&#39;bundles&#39;: [{&#39;expire_date&#39;: datetime.datetime(2023, 3, 9, 14, 9, 12),</span>
 <span class="go">   &#39;remaining_searches&#39;: 7892,</span>
-<span class="go">   &#39;start_date&#39;: datetime.datetime(2017, 3, 10, 14, 9, 12)},</span>
+<span class="go">   &#39;start_date&#39;: datetime.datetime(2021, 3, 10, 14, 9, 12)},</span>
 <span class="go">  {&#39;expire_date&#39;: datetime.datetime(2019, 3, 23, 9, 52, 46),</span>
 <span class="go">   &#39;remaining_searches&#39;: 50000,</span>
-<span class="go">   &#39;start_date&#39;: datetime.datetime(2017, 3, 24, 9, 52, 45)}],</span>
+<span class="go">   &#39;start_date&#39;: datetime.datetime(2021, 3, 24, 9, 52, 45)}],</span>
 <span class="go"> &#39;total_remaining_searches&#39;: 57892}</span>
 </pre></div>
 </div>

--- a/pytineye/__init__.py
+++ b/pytineye/__init__.py
@@ -3,7 +3,7 @@
 """
 __init__.py
 
-Copyright (c) 2017 TinEye. All rights reserved worldwide.
+Copyright (c) 2021 TinEye. All rights reserved worldwide.
 """
 
 from .api import TinEyeAPIRequest, TinEyeResponse, Match, Backlink

--- a/pytineye/api.py
+++ b/pytineye/api.py
@@ -5,7 +5,7 @@ api.py
 
 Python library to ease communication with the TinEye API server.
 
-Copyright (c) 2017 TinEye. All rights reserved worldwide.
+Copyright (c) 2021 TinEye. All rights reserved worldwide.
 """
 
 from datetime import datetime
@@ -242,12 +242,12 @@ class TinEyeAPIRequest(object):
     Getting information about your search bundle:
 
         >>> api.remaining_searches()
-        {'bundles': [{'expire_date': datetime.datetime(2019, 3, 9, 14, 9, 12),
+        {'bundles': [{'expire_date': datetime.datetime(2023, 3, 9, 14, 9, 12),
            'remaining_searches': 7892,
-           'start_date': datetime.datetime(2017, 3, 10, 14, 9, 12)},
+           'start_date': datetime.datetime(2021, 3, 10, 14, 9, 12)},
           {'expire_date': datetime.datetime(2019, 3, 23, 9, 52, 46),
            'remaining_searches': 50000,
-           'start_date': datetime.datetime(2017, 3, 24, 9, 52, 45)}],
+           'start_date': datetime.datetime(2021, 3, 24, 9, 52, 45)}],
          'total_remaining_searches': 57892}
 
     Getting an image count:

--- a/pytineye/api_request.py
+++ b/pytineye/api_request.py
@@ -6,7 +6,7 @@ api_request.py
 Provides authentication with the TinEye API server.
 For more information see https://services.tineye.com/developers/tineyeapi/authentication.html
 
-Copyright (c) 2017 TinEye. All rights reserved worldwide.
+Copyright (c) 2021 TinEye. All rights reserved worldwide.
 """
 
 from future.standard_library import install_aliases
@@ -266,8 +266,8 @@ class APIRequest(object):
             raise APIRequestError("Must specify an image to search for.")
 
         # Have to generate a boundary, nonce, and date to use in generating a POST
-        # request signature
-        boundary = email.generator._make_boundary()
+        # request signature, also needs to have starting --
+        boundary = email.generator._make_boundary().replace("=", "-")
         nonce = self._generate_nonce()
         date = int(time.time())
 

--- a/pytineye/api_request.py
+++ b/pytineye/api_request.py
@@ -9,19 +9,18 @@ For more information see https://services.tineye.com/developers/tineyeapi/authen
 Copyright (c) 2021 TinEye. All rights reserved worldwide.
 """
 
-from future.standard_library import install_aliases
-
-install_aliases()
-
+from hashlib import sha256 as sha
 import hmac
-import email.generator
+import sys
 import time
 import urllib.parse
 
-from hashlib import sha256 as sha
-
 from Crypto.Random import random
+from future.standard_library import install_aliases
+
 from .exceptions import APIRequestError
+
+install_aliases()
 
 
 class APIRequest(object):
@@ -39,7 +38,22 @@ class APIRequest(object):
         self.public_key = public_key
         self.private_key = private_key
 
-    def _generate_nonce(self, nonce_length=24):
+    @staticmethod
+    def _generate_boundary():
+        """
+        Generate a boundary string for a multipart request.
+        Adapted from Python's email.generator._make_boundary() method.
+
+        Returns: a boundary string.
+        """
+        width = len(repr(sys.maxsize - 1))
+        fmt = "%%0%dd" % width
+        token = random.randrange(sys.maxsize)
+        boundary = ("-" * 15) + (fmt % token) + "--"
+        return boundary
+
+    @staticmethod
+    def _generate_nonce(nonce_length=24):
         """
         Generate a nonce used to make a request unique.
 
@@ -65,12 +79,12 @@ class APIRequest(object):
         nonce = ""
         nonce = [
             rand.choice(APIRequest.nonce_allowable_chars)
-            for i in range(0, nonce_length)
+            for _ in range(0, nonce_length)
         ]
 
         return "".join(nonce)
 
-    def _generate_get_hmac_signature(self, method, nonce, date, request_params={}):
+    def _generate_get_hmac_signature(self, method, nonce, date, request_params=None):
         """
         Generate the HMAC signature hash for a GET request.
 
@@ -81,6 +95,10 @@ class APIRequest(object):
 
         Returns: an HMAC signature hash.
         """
+
+        if request_params is None:
+            request_params = {}
+
         http_verb = "GET"
 
         param_str = self._sort_params(request_params=request_params)
@@ -92,7 +110,7 @@ class APIRequest(object):
         return self._generate_hmac_signature(to_sign)
 
     def _generate_post_hmac_signature(
-        self, method, boundary, nonce, date, filename, request_params={}
+        self, method, boundary, nonce, date, filename, request_params=None
     ):
         """
         Generate the HMAC signature hash for a POST request.
@@ -106,6 +124,9 @@ class APIRequest(object):
 
         Returns: an HMAC signature hash.
         """
+
+        if request_params is None:
+            request_params = {}
 
         http_verb = "POST"
         content_type = "multipart/form-data; boundary=%s" % boundary
@@ -170,7 +191,7 @@ class APIRequest(object):
                 # Assume URL with % was already urlencoded
                 if param.lower() == "image_url":
                     value = request_params[param]
-                    if type(value) is bytes:
+                    if isinstance(value, bytes):
                         value = value.decode("utf-8")
                     # Lowercase and encode the URL if needed
                     url_escape = urllib.parse.quote_plus(value, "~")
@@ -227,7 +248,7 @@ class APIRequest(object):
 
         return request_url
 
-    def get_request(self, method, request_params={}):
+    def get_request(self, method, request_params=None):
         """
         Generate an API GET request string.
 
@@ -236,8 +257,12 @@ class APIRequest(object):
 
         Returns: a URL to send the search request to including the search parameters.
         """
+
+        if request_params is None:
+            request_params = {}
+
         # Have to generate a nonce and date to use in generating a GET request signature
-        nonce = self._generate_nonce()
+        nonce = APIRequest._generate_nonce()
         date = int(time.time())
 
         api_signature = self._generate_get_hmac_signature(
@@ -246,7 +271,7 @@ class APIRequest(object):
 
         return self._request_url(method, nonce, date, api_signature, request_params)
 
-    def post_request(self, method, filename, request_params={}):
+    def post_request(self, method, filename, request_params=None):
         """
         Generate an API POST request string for an image upload search.
 
@@ -262,12 +287,16 @@ class APIRequest(object):
         - `request_url`, the URL to send the search to.
         - `boundary`, the boundary to be used in the POST request.
         """
+
+        if request_params is None:
+            request_params = {}
+
         if filename is None or not len(str(filename).strip()):
             raise APIRequestError("Must specify an image to search for.")
 
         # Have to generate a boundary, nonce, and date to use in generating a POST
-        # request signature, also needs to have starting --
-        boundary = email.generator._make_boundary().replace("=", "-")
+        # request signature
+        boundary = APIRequest._generate_boundary()
         nonce = self._generate_nonce()
         date = int(time.time())
 

--- a/pytineye/exceptions.py
+++ b/pytineye/exceptions.py
@@ -5,7 +5,7 @@ exceptions.py
 
 Exception class for pytineye.
 
-Copyright (c) 2017 TinEye. All rights reserved worldwide.
+Copyright (c) 2021 TinEye. All rights reserved worldwide.
 """
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 
-version = "2.0.0"
+version = "2.0.1"
 
 setup(
     name="pytineye",
@@ -24,7 +24,7 @@ setup(
     tests_require=["nose"],
     install_requires=[
         "future==0.18.2",
-        "pycryptodome==3.9.9",
-        "urllib3[secure]==1.26.1",
+        "pycryptodome==3.10.1",
+        "urllib3[secure]==1.26.4",
     ],
 )

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -5,7 +5,7 @@ test_api_request.py
 
 Test TinEyeAPIRequest class.
 
-Copyright (c) 2017 TinEye. All rights reserved worldwide.
+Copyright (c) 2021 TinEye. All rights reserved worldwide.
 """
 
 from datetime import datetime

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -33,31 +33,31 @@ class TestTinEyeAPIRequest(unittest.TestCase):
 
         backlink = {"url": "url", "crawl_date": "2010-02-19", "backlink": "backlink"}
         b = Backlink._from_dict(backlink)
-        self.assertEquals(
+        self.assertEqual(
             repr(b),
             'Backlink(url="url", backlink="backlink", crawl_date=2010-02-19 00:00:00)',
         )
-        self.assertEquals(b.url, "url")
-        self.assertEquals(b.crawl_date, datetime(2010, 2, 19, 0, 0))
-        self.assertEquals(b.backlink, "backlink")
+        self.assertEqual(b.url, "url")
+        self.assertEqual(b.crawl_date, datetime(2010, 2, 19, 0, 0))
+        self.assertEqual(b.backlink, "backlink")
 
         backlink = {"url": "url", "crawl_date": "", "backlink": "backlink"}
         b = Backlink._from_dict(backlink)
-        self.assertEquals(b.url, "url")
-        self.assertEquals(b.crawl_date, datetime(1, 1, 1, 0, 0))
-        self.assertEquals(b.backlink, "backlink")
+        self.assertEqual(b.url, "url")
+        self.assertEqual(b.crawl_date, datetime(1, 1, 1, 0, 0))
+        self.assertEqual(b.backlink, "backlink")
 
         backlink = {"url": "", "crawl_date": "", "backlink": ""}
         b = Backlink._from_dict(backlink)
-        self.assertEquals(b.url, "")
-        self.assertEquals(b.crawl_date, datetime(1, 1, 1, 0, 0))
-        self.assertEquals(b.backlink, "")
+        self.assertEqual(b.url, "")
+        self.assertEqual(b.crawl_date, datetime(1, 1, 1, 0, 0))
+        self.assertEqual(b.backlink, "")
 
         backlink = {"url": None, "crawl_date": None, "backlink": None}
         b = Backlink._from_dict(backlink)
-        self.assertEquals(b.url, None)
-        self.assertEquals(b.crawl_date, datetime(1, 1, 1, 0, 0))
-        self.assertEquals(b.backlink, None)
+        self.assertEqual(b.url, None)
+        self.assertEqual(b.crawl_date, datetime(1, 1, 1, 0, 0))
+        self.assertEqual(b.backlink, None)
 
     def test_match(self):
         """ Test TinEyeAPI.Match object. """
@@ -79,20 +79,20 @@ class TestTinEyeAPIRequest(unittest.TestCase):
             "query_hash": "dca08fc6b2ec4b9e04f94a4e29223f6af3dd6555",
         }
         m = Match._from_dict(match)
-        self.assertEquals(
+        self.assertEqual(
             repr(m), 'Match(image_url="image_url", score=14.80, width=350, height=297)'
         )
-        self.assertEquals(len(m.backlinks), 1)
-        self.assertEquals(m.domain, "domain")
-        self.assertEquals(m.score, 14.8)
-        self.assertEquals(m.format, "JPEG")
-        self.assertEquals(m.overlay, "overlay")
-        self.assertEquals(m.height, 297)
-        self.assertEquals(m.width, 350)
-        self.assertEquals(m.image_url, "image_url")
-        self.assertEquals(m.filesize, 87918)
-        self.assertEquals(m.tags, [])
-        self.assertEquals(m.size, 103950)
+        self.assertEqual(len(m.backlinks), 1)
+        self.assertEqual(m.domain, "domain")
+        self.assertEqual(m.score, 14.8)
+        self.assertEqual(m.format, "JPEG")
+        self.assertEqual(m.overlay, "overlay")
+        self.assertEqual(m.height, 297)
+        self.assertEqual(m.width, 350)
+        self.assertEqual(m.image_url, "image_url")
+        self.assertEqual(m.filesize, 87918)
+        self.assertEqual(m.tags, [])
+        self.assertEqual(m.size, 103950)
 
         match = {
             "backlinks": [
@@ -111,17 +111,17 @@ class TestTinEyeAPIRequest(unittest.TestCase):
             "size": 103950,
         }
         m = Match._from_dict(match)
-        self.assertEquals(len(m.backlinks), 2)
-        self.assertEquals(m.domain, "domain")
-        self.assertEquals(m.score, 67.19)
-        self.assertEquals(m.format, "JPEG")
-        self.assertEquals(m.overlay, "overlay")
-        self.assertEquals(m.height, 297)
-        self.assertEquals(m.width, 350)
-        self.assertEquals(m.image_url, "image_url")
-        self.assertEquals(m.filesize, 87918)
-        self.assertEquals(m.tags, [])
-        self.assertEquals(m.size, 103950)
+        self.assertEqual(len(m.backlinks), 2)
+        self.assertEqual(m.domain, "domain")
+        self.assertEqual(m.score, 67.19)
+        self.assertEqual(m.format, "JPEG")
+        self.assertEqual(m.overlay, "overlay")
+        self.assertEqual(m.height, 297)
+        self.assertEqual(m.width, 350)
+        self.assertEqual(m.image_url, "image_url")
+        self.assertEqual(m.filesize, 87918)
+        self.assertEqual(m.tags, [])
+        self.assertEqual(m.size, 103950)
 
         match = {
             "backlinks": [],
@@ -135,17 +135,17 @@ class TestTinEyeAPIRequest(unittest.TestCase):
             "size": 103950,
         }
         m = Match._from_dict(match)
-        self.assertEquals(len(m.backlinks), 0)
-        self.assertEquals(m.domain, "")
-        self.assertEquals(m.score, 0)
-        self.assertEquals(m.format, "")
-        self.assertEquals(m.overlay, "")
-        self.assertEquals(m.height, None)
-        self.assertEquals(m.width, None)
-        self.assertEquals(m.image_url, "image_url")
-        self.assertEquals(m.filesize, 87918)
-        self.assertEquals(m.tags, [])
-        self.assertEquals(m.size, 103950)
+        self.assertEqual(len(m.backlinks), 0)
+        self.assertEqual(m.domain, "")
+        self.assertEqual(m.score, 0)
+        self.assertEqual(m.format, "")
+        self.assertEqual(m.overlay, "")
+        self.assertEqual(m.height, None)
+        self.assertEqual(m.width, None)
+        self.assertEqual(m.image_url, "image_url")
+        self.assertEqual(m.filesize, 87918)
+        self.assertEqual(m.tags, [])
+        self.assertEqual(m.size, 103950)
 
     def test_tineye_response(self):
         """ Test TinEyeAPI.TinEyeResponse object. """
@@ -170,13 +170,13 @@ class TestTinEyeAPIRequest(unittest.TestCase):
             }
         }
         r = TinEyeResponse._from_dict(matches)
-        self.assertEquals(
+        self.assertEqual(
             repr(r),
             'TinEyeResponse(matches=[Match(image_url="", score=89.36, width=350, height=297)], stats={})',
         ),
-        self.assertEquals(len(r.matches), 1)
-        self.assertEquals(r.matches[0].height, 297)
-        self.assertEquals(r.matches[0].width, 350)
+        self.assertEqual(len(r.matches), 1)
+        self.assertEqual(r.matches[0].height, 297)
+        self.assertEqual(r.matches[0].width, 350)
 
         matches = {
             "results": {
@@ -211,13 +211,13 @@ class TestTinEyeAPIRequest(unittest.TestCase):
             }
         }
         r = TinEyeResponse._from_dict(matches)
-        self.assertEquals(len(r.matches), 2)
-        self.assertEquals(r.matches[1].height, 200)
-        self.assertEquals(r.matches[1].width, 300)
+        self.assertEqual(len(r.matches), 2)
+        self.assertEqual(r.matches[1].height, 200)
+        self.assertEqual(r.matches[1].width, 300)
 
         matches = {"results": {"matches": []}}
         r = TinEyeResponse._from_dict(matches)
-        self.assertEquals(len(r.matches), 0)
+        self.assertEqual(len(r.matches), 0)
 
     def test_calls(self):
         """ Test methods with API sandbox. """

--- a/test/test_api_request.py
+++ b/test/test_api_request.py
@@ -47,25 +47,25 @@ class TestAPIRequest(unittest.TestCase):
         try:
             self.request._generate_nonce(nonce_length=0)
         except APIRequestError as e:
-            self.assertEquals(
+            self.assertEqual(
                 e.args[0], "Nonce length must be an int between 24 and 255 chars"
             )
 
         try:
             self.request._generate_nonce(nonce_length="character")
         except APIRequestError as e:
-            self.assertEquals(
+            self.assertEqual(
                 e.args[0], "Nonce length must be an int between 24 and 255 chars"
             )
 
         nonce = self.request._generate_nonce(nonce_length=24)
-        self.assertEquals(len(nonce), 24)
+        self.assertEqual(len(nonce), 24)
 
         for char in nonce:
             self.assertTrue(char in allowable_chars)
 
         nonce = self.request._generate_nonce(nonce_length=36)
-        self.assertEquals(len(nonce), 36)
+        self.assertEqual(len(nonce), 36)
 
         for char in nonce:
             self.assertTrue(char in allowable_chars)
@@ -78,13 +78,13 @@ class TestAPIRequest(unittest.TestCase):
         """
 
         signature = self.request._generate_hmac_signature("")
-        self.assertEquals(
+        self.assertEqual(
             signature,
             "70eaf20393eb0605270226d522dfd19d281e64ea513c271c9e6febdd826a5f7c",
         )
 
         signature = self.request._generate_hmac_signature(" ")
-        self.assertEquals(
+        self.assertEqual(
             signature,
             "5f5f7e12a03ce8ac37ef8e98ac77dad52f0d380752ab4928c9e828949eb4e721",
         )
@@ -92,7 +92,7 @@ class TestAPIRequest(unittest.TestCase):
         signature = self.request._generate_hmac_signature(
             "this is a message to convert"
         )
-        self.assertEquals(
+        self.assertEqual(
             signature,
             "a5cb1334a32b5bb43755393be47aea8182a8557097e0f70803dc85b8d4d18562",
         )
@@ -100,7 +100,7 @@ class TestAPIRequest(unittest.TestCase):
         signature = self.request._generate_hmac_signature(
             "this is another message to convert"
         )
-        self.assertEquals(
+        self.assertEqual(
             signature,
             "ce7c686d266ebeb4e8e9dc1d1cb3d88b72ed8d4f3be41096aa3c397e45ade372",
         )
@@ -110,7 +110,7 @@ class TestAPIRequest(unittest.TestCase):
         signature = self.request._generate_get_hmac_signature(
             "image_count", nonce, date
         )
-        self.assertEquals(
+        self.assertEqual(
             signature,
             "dfc8b4735ab41c907059b473727bd500645f161398133db1c2ebdf276221d681",
         )
@@ -118,7 +118,7 @@ class TestAPIRequest(unittest.TestCase):
         signature = self.request._generate_get_hmac_signature(
             "remaining_searches", nonce, date, request_params={"param_1": "value"}
         )
-        self.assertEquals(
+        self.assertEqual(
             signature,
             "3b055b83d6e32f1604328306a51ba9b243f52986ba0458a7915d864d00d2f04e",
         )
@@ -127,7 +127,7 @@ class TestAPIRequest(unittest.TestCase):
         signature = self.request._generate_post_hmac_signature(
             "search", boundary, nonce, date, filename="file"
         )
-        self.assertEquals(
+        self.assertEqual(
             signature,
             "26e789aaaf7e3f0b3c2eea15ba385a1e22da6cf93698ec98ea61627c84e35a5e",
         )
@@ -140,7 +140,7 @@ class TestAPIRequest(unittest.TestCase):
             filename="file",
             request_params={"param_1": "value"},
         )
-        self.assertEquals(
+        self.assertEqual(
             signature,
             "79232caabb7433561142f465cb2e645197bbc5c56a3d3832884d8e24ed128e33",
         )
@@ -150,15 +150,15 @@ class TestAPIRequest(unittest.TestCase):
 
         request_params = {}
         sorted_params = self.request._sort_params(request_params)
-        self.assertEquals(sorted_params, "")
+        self.assertEqual(sorted_params, "")
 
         request_params = {"a_param": "value_1"}
         sorted_params = self.request._sort_params(request_params)
-        self.assertEquals(sorted_params, "a_param=value_1")
+        self.assertEqual(sorted_params, "a_param=value_1")
 
         request_params = {"a_param": "value_1", "b_param": "value_2"}
         sorted_params = self.request._sort_params(request_params)
-        self.assertEquals(sorted_params, "a_param=value_1&b_param=value_2")
+        self.assertEqual(sorted_params, "a_param=value_1&b_param=value_2")
 
         request_params = {
             "param_1": "value_1",
@@ -166,7 +166,7 @@ class TestAPIRequest(unittest.TestCase):
             "b_param": "value_3",
         }
         sorted_params = self.request._sort_params(request_params)
-        self.assertEquals(
+        self.assertEqual(
             sorted_params, "a_param=value_2&b_param=value_3&param_1=value_1"
         )
 
@@ -177,7 +177,7 @@ class TestAPIRequest(unittest.TestCase):
             "b_param": "value_3",
         }
         sorted_params = self.request._sort_params(request_params)
-        self.assertEquals(
+        self.assertEqual(
             sorted_params, "a_param=value_2&b_param=value_3&param_1=value_1"
         )
 
@@ -188,7 +188,7 @@ class TestAPIRequest(unittest.TestCase):
             "a_param": "value_2",
         }
         sorted_params = self.request._sort_params(request_params)
-        self.assertEquals(sorted_params, "a_param=value_2&param_1=value_1")
+        self.assertEqual(sorted_params, "a_param=value_2&param_1=value_1")
 
         request_params = {
             "api_key": "a_key",
@@ -197,23 +197,23 @@ class TestAPIRequest(unittest.TestCase):
             "nonce": "nonce",
         }
         sorted_params = self.request._sort_params(request_params)
-        self.assertEquals(sorted_params, "")
+        self.assertEqual(sorted_params, "")
 
         request_params = {"image_url": "valu$_1"}
         sorted_params = self.request._sort_params(request_params)
-        self.assertEquals(sorted_params, "image_url=valu%24_1")
+        self.assertEqual(sorted_params, "image_url=valu%24_1")
 
         request_params = {"image_url": "CAPS!??!?!"}
         sorted_params = self.request._sort_params(request_params)
-        self.assertEquals(sorted_params, "image_url=caps%21%3f%3f%21%3f%21")
+        self.assertEqual(sorted_params, "image_url=caps%21%3f%3f%21%3f%21")
 
         request_params = {"image_url": "CAPS%21%3f%3f%21%3f%21"}
         sorted_params = self.request._sort_params(request_params)
-        self.assertEquals(sorted_params, "image_url=caps%2521%253f%253f%2521%253f%2521")
+        self.assertEqual(sorted_params, "image_url=caps%2521%253f%253f%2521%253f%2521")
 
         request_params = {"Image_Url": "CAPS%21%3f%3f%21%3f%21"}
         sorted_params = self.request._sort_params(request_params)
-        self.assertEquals(sorted_params, "image_url=caps%2521%253f%253f%2521%253f%2521")
+        self.assertEqual(sorted_params, "image_url=caps%2521%253f%253f%2521%253f%2521")
 
     def test_request_url(self):
         """ Test APIRequest._request_url(). """
@@ -224,7 +224,7 @@ class TestAPIRequest(unittest.TestCase):
         url = self.request._request_url(
             "search", nonce, date, "api_sig", {"a_param": "value_1"}
         )
-        self.assertEquals(
+        self.assertEqual(
             url,
             (
                 "https://api.tineye.com/rest/search/?api_key=LCkn,2K7osVwkX95K4Oy&date=1345821763"
@@ -239,7 +239,7 @@ class TestAPIRequest(unittest.TestCase):
             "api_sig",
             {"param_1": "value_1", "a_param": "value_2", "b_param": "value_3"},
         )
-        self.assertEquals(
+        self.assertEqual(
             url,
             (
                 "https://api.tineye.com/rest/search/?api_key=LCkn,2K7osVwkX95K4Oy&date=1345821763"
@@ -250,7 +250,7 @@ class TestAPIRequest(unittest.TestCase):
         url = self.request._request_url(
             "search", nonce, date, "api_sig", {"image_url": "CAPS?!!?"}
         )
-        self.assertEquals(
+        self.assertEqual(
             url,
             (
                 "https://api.tineye.com/rest/search/?api_key=LCkn,2K7osVwkX95K4Oy&date=1345821763"

--- a/test/test_api_request.py
+++ b/test/test_api_request.py
@@ -5,7 +5,7 @@ test_api_request.py
 
 Test APIRequest class.
 
-Copyright (c) 2017 TinEye. All rights reserved worldwide.
+Copyright (c) 2021 TinEye. All rights reserved worldwide.
 """
 
 import unittest


### PR DESCRIPTION
- Multipart boundary strings should start and end with `--`.
- Updating some dependencies.