### PR TITLE
fixed install for python2.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,12 @@ from os import path
 
 from setuptools import find_packages, setup
 
-version = "3.0.0"
+version = "3.0.1"
 
 
 # read the contents of your README file
 this_directory = path.abspath(path.dirname(__file__))
-with open(path.join(this_directory, "README.md"), encoding="utf-8") as f:
+with open(path.join(this_directory, "README.md")) as f:
     long_description = f.read()
 
 setup(


### PR DESCRIPTION
Removed encoding option from open call which broke the install for python2.7