### PR TITLE
Docs: update 'format' Match attr to 'image_format'

### DIFF
--- a/pytineye/api.py
+++ b/pytineye/api.py
@@ -89,7 +89,7 @@ class Match(object):
     - `width`, image width in pixels.
     - `height`, image height in pixels.
     - `size`, image area in pixels.
-    - `format`, image format.
+    - `image_format`, image format.
     - `filesize`, image size in bytes.
     - `overlay`, overlay URL.
     - `backlinks`, a list of Backlink objects pointing to


### PR DESCRIPTION
I noticed this after looking into why I was getting "unexpected keyword argument" errors for 'format'